### PR TITLE
마이페이지에 프로필 깃허브 뱃지 추가

### DIFF
--- a/app/(user)/my/components/GithubBadge.tsx
+++ b/app/(user)/my/components/GithubBadge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { Github } from "lucide-react";
+
+interface GithubBadgeProps {
+  githubUrl: string;
+}
+
+export function GithubBadge({ githubUrl }: GithubBadgeProps) {
+  const username = githubUrl.split("/").pop();
+
+  return (
+    <Link
+      href={githubUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group inline-flex items-center justify-center bg-black rounded-full h-6 w-6 hover:w-[120px] transition-all duration-300 overflow-hidden"
+    >
+      <Github className="h-4 w-4 text-white shrink-0" />
+      <span className="ml-2 text-white text-xs whitespace-nowrap hidden group-hover:inline">
+        @{username}
+      </span>
+    </Link>
+  );
+}

--- a/app/(user)/my/components/Profile.tsx
+++ b/app/(user)/my/components/Profile.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { GithubBadge } from "./GithubBadge";
 import { Button } from "@/components/ui/button";
 import { Github, Mail } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/MyTooltip";
@@ -6,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/MyTooltip";
 const user = {
   name: "서현우",
   email: "seohyun@example.com",
-  github: "https://github.com/seohyun",
+  github: "https://github.com/Harang-Dev",
   introduce: "안녕하세요, 서현우입니다. 개발자입니다.",
   image: "/images/sample-image.jpg",
   followers: 120,
@@ -34,13 +35,8 @@ export function Profile({ onEditClick }: ProfileProps) {
 
         <div className="grid grid-rows-2 gap-y-0">
           <div className="flex flex-row items-center gap-1">
-            <h3 className="text-lg font-bold mt-1">{user.name}</h3>
-            {user.github ? (
-              <div className="w-18 h-5 bg-secondary rounded-full flex items-center justify-center text-white">
-                <Github className="h-4 w-4" />
-                <span className="text-xs ml-1">GitHub</span>
-              </div>
-            ) : null}
+            <h3 className="text-lg font-bold">{user.name}</h3>
+            <GithubBadge githubUrl={user.github} />
           </div>
           <div className="flex flex-row items-center gap-2 pb-2">
             <Tooltip>


### PR DESCRIPTION
## 📌 이슈 번호
close #27 

## ✨ 작업 내용

- 마이페이지 프로필탭에 사용할 깃허브 뱃지를 추가했습니다.
- 마우스 hover해서 확인 가능하고, 클릭하면 깃허브 프로필로 이동합니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

![깃허브뱃지](https://github.com/user-attachments/assets/5e23ac1b-a17c-459b-845a-329a375dee06)

## 💬 기타 참고 사항
