### PR TITLE
팔로우/언팔로우 API 연동 및 버튼 상태 관리 구현

### DIFF
--- a/apis/my/ProfileApi.ts
+++ b/apis/my/ProfileApi.ts
@@ -107,3 +107,31 @@ export async function logout() {
     throw err;
   }
 }
+
+export async function createUserFollow(followingId: number) {
+  try {
+    const res = await axios.post(
+      `${API_URL}/api/v1/follow/${followingId}`,
+      null,
+      {
+        withCredentials: true,
+      },
+    );
+    return res.data;
+  } catch (err) {
+    console.error("팔로우 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function deleteUserFollow(followingId: number) {
+  try {
+    const res = await axios.delete(`${API_URL}/api/v1/follow/${followingId}`, {
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("언팔로우 요청 실패:", err);
+    throw err;
+  }
+}

--- a/app/(user)/my/components/Follower.tsx
+++ b/app/(user)/my/components/Follower.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { Plus, Check } from "lucide-react";
+import { createUserFollow, deleteUserFollow } from "@/apis/my/ProfileApi";
+import axios from "axios";
 
 interface Follower {
   userId: number;
@@ -11,14 +14,42 @@ interface Follower {
 
 export function Follower({
   user,
-  following,
+  following: initialFollowing = [],
 }: {
   user?: Follower[];
   following?: Follower[];
 }) {
+  const [following, setFollowing] = useState<Follower[]>(initialFollowing);
+  console.log("유저", user);
+  console.log("팔로우", following);
   if (!user) {
     return <div>팔로우한 사용자가 존재하지 않습니다</div>;
   }
+  const isFollowing = (userId: number) =>
+    following.some(f => f.userId === userId);
+
+  const handleFollow = async (person: Follower) => {
+    try {
+      await createUserFollow(person.userId);
+      setFollowing(prev => [...prev, person]);
+    } catch (err) {
+      console.error("팔로우 요청 실패:", err);
+    }
+  };
+
+  const handleUnfollow = async (userId: number) => {
+    try {
+      await deleteUserFollow(userId);
+      setFollowing(prev => prev.filter(f => f.userId !== userId));
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        console.warn("이미 언팔로우된 사용자입니다.");
+        setFollowing(prev => prev.filter(f => f.userId !== userId));
+      } else {
+        console.error("언팔로우 요청 실패:", err);
+      }
+    }
+  };
 
   return (
     <>
@@ -41,10 +72,11 @@ export function Follower({
             </div>
           </div>
           <div className="flex justify-end">
-            {following && following.some(f => f.userId === person.userId) ? (
+            {isFollowing(person.userId) ? (
               <Button
                 variant="outline"
                 className="bg-[#1f9eff] text-white w-[129px] h-[40px] hover:bg-[#0064ff]"
+                onClick={() => handleUnfollow(person.userId)}
               >
                 <Check /> 팔로잉
               </Button>
@@ -52,6 +84,7 @@ export function Follower({
               <Button
                 variant="outline"
                 className="text-[#1f8ce6] w-[129px] h-[40px] hover:bg-[#0064ff] hover:text-white"
+                onClick={() => handleFollow(person)}
               >
                 <Plus /> 팔로우
               </Button>


### PR DESCRIPTION
## 📌 이슈 번호
- #62 
## ✨ 작업 내용

- createUserFollow, deleteUserFollow API 함수 추가 (withCredentials: true 포함)
- 팔로우/언팔로우 버튼 클릭 시 API 호출 및 상태 동기화 처리 (Follower.tsx)
- 팔로우 여부를 확인하는 isFollowing 추가
- 기존 하드코딩된 조건 분기 (following.some) → 함수 분리하여 가독성 향상
- 404 응답에 대한 예외 처리 (이미 언팔로우된 사용자 예외 케이스 대응)

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
