### PR TITLE
프로필 기능 통합 (계좌/이메일 인증 + 팔로우 기능 연동)

### DIFF
--- a/apis/my/ProfileApi.ts
+++ b/apis/my/ProfileApi.ts
@@ -1,0 +1,58 @@
+import axios from "axios";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export async function checkUserEmail(email: string) {
+  try {
+    const res = await axios.get(`${API_URL}/api/v1/user/check-email`, {
+      params: { email },
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err: unknown) {
+    if (axios.isAxiosError(err)) {
+      if (err.response?.status === 409) {
+        return 409;
+      }
+      console.error("Axios 오류 응답:", err.response);
+    } else {
+      console.error("알 수 없는 오류:", err);
+    }
+    throw err;
+  }
+}
+
+export async function sendVerificationEmail(email: string) {
+  try {
+    const res = await axios.post(
+      `${API_URL}/api/v1/user/send-verification?email=${email}`,
+      null,
+      {
+        withCredentials: true,
+      },
+    );
+    return res.data;
+  } catch (err) {
+    console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function sendVerificationResult(
+  email: string,
+  verificationCode: string,
+) {
+  try {
+    const res = await axios.post(`${API_URL}/api/v1/user/verify-code`, null, {
+      params: {
+        email,
+        code: verificationCode,
+      },
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}

--- a/apis/my/ProfileApi.ts
+++ b/apis/my/ProfileApi.ts
@@ -107,3 +107,31 @@ export async function logout() {
     throw err;
   }
 }
+
+export async function createUserFollow(followingId: number) {
+  try {
+    const res = await axios.post(
+      `${API_URL}/api/v1/follow/${followingId}`,
+      null,
+      {
+        withCredentials: true,
+      },
+    );
+    return res.data;
+  } catch (err) {
+    console.error("팔로우 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function deleteUserFollow(followingId: number) {
+  try {
+    const res = await axios.delete(`${API_URL}/api/v1/follow/${followingId}`, {
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("언팔로우 요청 실패:", err);
+    throw err;
+  }
+}

--- a/apis/my/ProfileApi.ts
+++ b/apis/my/ProfileApi.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
 export async function checkUserEmail(email: string) {
   try {
     const res = await axios.get(`${API_URL}/api/v1/user/check-email`, {
@@ -53,6 +52,58 @@ export async function sendVerificationResult(
     return res.data;
   } catch (err) {
     console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function getUserAccount() {
+  try {
+    const res = await axios.get(`${API_URL}/api/v1/user/mypage/account`, {
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function updateUserAccount(bank: string, account: string) {
+  try {
+    const res = await axios.put(
+      `${API_URL}/api/v1/user/mypage/account`,
+      { bank, account },
+      {
+        withCredentials: true,
+      },
+    );
+    return res.data;
+  } catch (err) {
+    console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function deleteUserAccount() {
+  try {
+    const res = await axios.delete(`${API_URL}/api/v1/user/mypage/account`, {
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("이메일 인증 요청 실패:", err);
+    throw err;
+  }
+}
+
+export async function logout() {
+  try {
+    const res = await axios.post(`${API_URL}/api/v1/user/logout`, null, {
+      withCredentials: true,
+    });
+    return res.data;
+  } catch (err) {
+    console.error("로그아웃 요청 실패:", err);
     throw err;
   }
 }

--- a/apis/my/useUserOrderList.ts
+++ b/apis/my/useUserOrderList.ts
@@ -13,7 +13,7 @@ export function useUserOrderList() {
           },
         );
 
-        setUserOrderData(res.data);
+        setUserOrderData(res.data.data);
       } catch (err) {
         console.error("로그인 필요 또는 인증 실패:", err);
       }

--- a/app/(user)/my/components/AccountSection.tsx
+++ b/app/(user)/my/components/AccountSection.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { MyCard, MyCardContent, MyCardHeader, MyCardTitle } from "./ui/MyCard";
+import { Trash2, Plus } from "lucide-react";
+import {
+  getUserAccount,
+  updateUserAccount,
+  deleteUserAccount,
+} from "@/apis/my/ProfileApi";
+
+interface AccountInfo {
+  bank: string;
+  account: string;
+}
+
+export function AccountSection() {
+  const [accountInfo, setAccountInfo] = useState<AccountInfo>({
+    bank: "",
+    account: "",
+  });
+  const [isEditing, setIsEditing] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasAccount, setHasAccount] = useState(false);
+
+  useEffect(() => {
+    loadAccountInfo();
+  }, []);
+
+  const loadAccountInfo = async () => {
+    try {
+      const result = await getUserAccount();
+      if (result.data) {
+        setAccountInfo(result.data);
+        setHasAccount(true);
+      }
+    } catch (error) {
+      console.error("계좌 정보 로드 실패:", error);
+    }
+  };
+
+  const handleSaveAccount = async () => {
+    if (!accountInfo.bank || !accountInfo.account) {
+      alert("은행과 계좌번호를 모두 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      await updateUserAccount(accountInfo.bank, accountInfo.account);
+      alert("계좌 정보가 저장되었습니다.");
+      setHasAccount(true);
+      setIsEditing(false);
+    } catch (error) {
+      alert("계좌 정보 저장에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!confirm("계좌 정보를 삭제하시겠습니까?")) return;
+
+    try {
+      setIsLoading(true);
+      await deleteUserAccount();
+      setAccountInfo({ bank: "", account: "" });
+      setHasAccount(false);
+      setIsEditing(false);
+      alert("계좌 정보가 삭제되었습니다.");
+    } catch (error) {
+      alert("계좌 정보 삭제에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <MyCard>
+      <MyCardHeader>
+        <div className="flex items-center justify-between">
+          <MyCardTitle>계좌 정보</MyCardTitle>
+          {hasAccount && !isEditing && (
+            <div className="space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditing(true)}
+              >
+                수정
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleDeleteAccount}
+                disabled={isLoading}
+                className="text-red-600 hover:text-red-700 bg-transparent"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </MyCardHeader>
+      <MyCardContent>
+        {!hasAccount || isEditing ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">은행</label>
+                <Input
+                  value={accountInfo.bank ?? ""}
+                  onChange={e =>
+                    setAccountInfo({ ...accountInfo, bank: e.target.value })
+                  }
+                  placeholder="은행명을 입력하세요"
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">계좌번호</label>
+                <Input
+                  value={accountInfo.account ?? ""}
+                  onChange={e =>
+                    setAccountInfo({ ...accountInfo, account: e.target.value })
+                  }
+                  placeholder="계좌번호를 입력하세요"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                onClick={handleSaveAccount}
+                disabled={isLoading}
+                className="bg-blue-500 hover:bg-blue-600"
+              >
+                {isLoading ? "저장 중..." : "저장"}
+              </Button>
+              {isEditing && (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setIsEditing(false);
+                    loadAccountInfo();
+                  }}
+                >
+                  취소
+                </Button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+              <div>
+                <p className="font-medium">{accountInfo.bank}</p>
+                <p className="text-gray-600">{accountInfo.account}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!hasAccount && !isEditing && (
+          <Button
+            onClick={() => setIsEditing(true)}
+            variant="outline"
+            className="w-full"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            계좌 등록
+          </Button>
+        )}
+      </MyCardContent>
+    </MyCard>
+  );
+}

--- a/app/(user)/my/components/Follower.tsx
+++ b/app/(user)/my/components/Follower.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { Plus, Check } from "lucide-react";
+import { createUserFollow, deleteUserFollow } from "@/apis/my/ProfileApi";
+import axios from "axios";
 
 interface Follower {
   userId: number;
@@ -11,14 +14,42 @@ interface Follower {
 
 export function Follower({
   user,
-  following,
+  following: initialFollowing = [],
 }: {
   user?: Follower[];
   following?: Follower[];
 }) {
+  const [following, setFollowing] = useState<Follower[]>(initialFollowing);
+  console.log("유저", user);
+  console.log("팔로우", following);
   if (!user) {
     return <div>팔로우한 사용자가 존재하지 않습니다</div>;
   }
+  const isFollowing = (userId: number) =>
+    following.some(f => f.userId === userId);
+
+  const handleFollow = async (person: Follower) => {
+    try {
+      await createUserFollow(person.userId);
+      setFollowing(prev => [...prev, person]);
+    } catch (err) {
+      console.error("팔로우 요청 실패:", err);
+    }
+  };
+
+  const handleUnfollow = async (userId: number) => {
+    try {
+      await deleteUserFollow(userId);
+      setFollowing(prev => prev.filter(f => f.userId !== userId));
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        console.warn("이미 언팔로우된 사용자입니다.");
+        setFollowing(prev => prev.filter(f => f.userId !== userId));
+      } else {
+        console.error("언팔로우 요청 실패:", err);
+      }
+    }
+  };
 
   return (
     <>
@@ -41,10 +72,11 @@ export function Follower({
             </div>
           </div>
           <div className="flex justify-end">
-            {following && following.some(f => f.userId === person.userId) ? (
+            {isFollowing(person.userId) ? (
               <Button
                 variant="outline"
                 className="bg-[#1f9eff] text-white w-[129px] h-[40px] hover:bg-[#0064ff]"
+                onClick={() => handleUnfollow(person.userId)}
               >
                 <Check /> 팔로잉
               </Button>
@@ -52,6 +84,7 @@ export function Follower({
               <Button
                 variant="outline"
                 className="text-[#1f8ce6] w-[129px] h-[40px] hover:bg-[#0064ff] hover:text-white"
+                onClick={() => handleFollow(person)}
               >
                 <Plus /> 팔로우
               </Button>

--- a/app/(user)/my/components/Profile.tsx
+++ b/app/(user)/my/components/Profile.tsx
@@ -2,6 +2,7 @@ import { Mail } from "lucide-react";
 import Image from "next/image";
 
 import { useFollowCount } from "@/apis/my/useFollowCount";
+import { useUserOrderList } from "@/apis/my/useUserOrderList";
 import { Button } from "@/components/ui/button";
 
 import { GithubBadge } from "./GithubBadge";
@@ -24,6 +25,7 @@ interface ProfileProps {
 }
 export function Profile({ user, onEditClick, purchaseProject }: ProfileProps) {
   const followData = useFollowCount();
+  const userOrderList = useUserOrderList();
 
   return (
     <div className="flex flex-row items-center justify-between pt-[20px] pd-[20px]">
@@ -78,8 +80,11 @@ export function Profile({ user, onEditClick, purchaseProject }: ProfileProps) {
             </div>
 
             <div className="grid grid-rows-2">
-              <p className="text-[#868e96] text-sm">후원수</p>
-              <p className="font-bold">0</p>
+              <p className="text-[#868e96] text-sm">프로젝트 수</p>
+              {/*아직 후원 관련 api 없으므로 프로젝트 수로 대체*/}
+              <p className="font-bold">
+                {userOrderList?.allProjectCount ?? "0"}
+              </p>
             </div>
           </div>
         </div>

--- a/app/(user)/my/components/Profile.tsx
+++ b/app/(user)/my/components/Profile.tsx
@@ -6,7 +6,12 @@ import { useUserOrderList } from "@/apis/my/useUserOrderList";
 import { Button } from "@/components/ui/button";
 
 import { GithubBadge } from "./GithubBadge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/MyTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/MyTooltip";
 
 export interface User {
   name: string;
@@ -28,61 +33,62 @@ export function Profile({ user, onEditClick, purchaseProject }: ProfileProps) {
   const userOrderList = useUserOrderList();
 
   return (
-    <div className="flex flex-row items-center justify-between pt-[20px] pd-[20px]">
-      <div className="flex flex-row items-center gap-8">
-        <div className="items-center justify-center">
+    <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between pt-5 pb-5 gap-6">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6 flex-1">
+        <div className="flex-shrink-0">
           <Image
-            src={user.image || "/images/sample-image.jpg"}
+            src={user.image || "/images/sample-image.jpg?height=100&width=100"}
             width={100}
             height={100}
             alt="Profile Picture"
-            className="rounded-full"
+            className="rounded-full object-cover border-2 border-gray-100"
           />
         </div>
 
-        <div className="grid grid-rows-2 gap-y-0">
-          <div className="flex flex-row items-center gap-1">
-            <h3 className="text-lg font-bold">{user.name}</h3>
-            {user.portfolioAddress ? (
-              <GithubBadge githubUrl={user.portfolioAddress} />
-            ) : null}
-          </div>
-          <div className="flex flex-row items-center gap-2 pb-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Mail className="h-4 w-4" />
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>해당 이메일은 다른 사용자에게 보이지 않습니다.</p>
-              </TooltipContent>
-            </Tooltip>
-            <p className="text-sm">{user.email}</p>
-          </div>
-
-          <div className="grid grid-cols-4 gap-10 text-center">
-            <div className="grid grid-rows-2">
-              <p className="text-[#868e96] text-sm">팔로잉</p>
-              <p className="font-bold">
-                {followData?.data?.followerCount ?? "0"}
-              </p>
+        <div className="flex-1 space-y-4">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-xl font-bold text-gray-900">{user.name}</h3>
+              {user.portfolioAddress ? (
+                <GithubBadge githubUrl={user.portfolioAddress} />
+              ) : null}
             </div>
 
-            <div className="grid grid-rows-2">
-              <p className="text-[#868e96] text-sm">팔로워</p>
-              <p className="font-bold">
+            <TooltipProvider>
+              <div className="flex items-center gap-2 text-gray-600">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Mail className="h-4 w-4" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>해당 이메일은 다른 사용자에게 보이지 않습니다.</p>
+                  </TooltipContent>
+                </Tooltip>
+                <p className="text-sm">{user.email}</p>
+              </div>
+            </TooltipProvider>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+            <div className="space-y-1">
+              <p className="text-gray-500 text-sm">팔로잉</p>
+              <p className="font-bold text-lg">
                 {followData?.data?.followingCount ?? "0"}
               </p>
             </div>
-
-            <div className="grid grid-rows-2">
-              <p className="text-[#868e96] text-sm">구매수</p>
-              <p className="font-bold">{purchaseProject}</p>
+            <div className="space-y-1">
+              <p className="text-gray-500 text-sm">팔로워</p>
+              <p className="font-bold text-lg">
+                {followData?.data?.followerCount ?? "0"}
+              </p>
             </div>
-
-            <div className="grid grid-rows-2">
-              <p className="text-[#868e96] text-sm">프로젝트 수</p>
-              {/*아직 후원 관련 api 없으므로 프로젝트 수로 대체*/}
-              <p className="font-bold">
+            <div className="space-y-1">
+              <p className="text-gray-500 text-sm">구매수</p>
+              <p className="font-bold text-lg">{purchaseProject}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-gray-500 text-sm">프로젝트 수</p>
+              <p className="font-bold text-lg">
                 {userOrderList?.allProjectCount ?? "0"}
               </p>
             </div>
@@ -90,13 +96,11 @@ export function Profile({ user, onEditClick, purchaseProject }: ProfileProps) {
         </div>
       </div>
 
-      <div>
+      <div className="flex-shrink-0">
         <Button
-          variant="outline"
-          className="hover:bg-[#0064ff] bg-[#1f9eff] text-white"
-          onClick={() => {
-            onEditClick(true);
-          }}
+          variant="default"
+          className="bg-blue-500 hover:bg-blue-600 text-white px-6"
+          onClick={() => onEditClick(true)}
         >
           내 정보 수정
         </Button>

--- a/app/(user)/my/components/ProfileEditForm.tsx
+++ b/app/(user)/my/components/ProfileEditForm.tsx
@@ -126,7 +126,6 @@ export function ProfileEditForm({
         throw new Error("프로필 수정 실패");
       }
 
-      const result = await response;
       onSubmitSuccess();
       onProfileClick(false);
     } catch (error) {

--- a/app/(user)/my/components/ui/MyCard.tsx
+++ b/app/(user)/my/components/ui/MyCard.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function MyCard({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-gray-200 py-6 shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MyCardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MyCardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function MyCardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export { MyCard, MyCardHeader, MyCardTitle, MyCardContent };

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-select": "^2.2.5",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -56,7 +57,7 @@
         "tailwindcss": "^4.1.11",
         "ts-node": "^10.9.2",
         "tw-animate-css": "^1.3.4",
-        "typescript": "^5.8.3"
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1394,6 +1395,29 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",


### PR DESCRIPTION
## 📌 이슈 번호
- #65
   - (feat/follow에서 feat/profile에 merge한 pr)
- close #62 
- close #64 
- close #63 

## ✨ 작업 내용

- 마이페이지 이메일 인증 API 추가
    - 이메일 인증 요청 API 및 인증코드 검증 로직 구현
- 계좌 정보 등록 기능
    - 계좌 등록 폼 및 관련 API 연동
    - 계좌 등록 시 이메일 인증 로직 포함
- shadcn UI 컴포넌트 적용
    - 카드(card), 구분선(separator) 컴포넌트 도입
- 프로필 영역 수정
    - 후원수 → 프로젝트 수로 변경
- 불필요 코드 정리
    - 사용하지 않는 코드 제거
    - UserOrderList 리팩토링 (필요한 데이터만 전달)
- 팔로우/언팔로우 기능 구현
    - 팔로우/언팔로우 API 구현
    - 프로필 카드에서 버튼 상태에 따라 API 호출 및 UI 변경사용하지 않는 코드 제거

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
- 이메일 인증 후에만 계좌 등록이 가능하도록 로직이 연동되어 있습니다!
- shadcn 컴포넌트 다운로드로 인해 패키지 제이슨 파일이 변경 되었습니다!